### PR TITLE
Add Version in sist2-admin

### DIFF
--- a/sist2-admin/frontend/src/components/NavBar.vue
+++ b/sist2-admin/frontend/src/components/NavBar.vue
@@ -3,7 +3,11 @@
     <b-navbar-brand to="/">
       <Sist2Icon></Sist2Icon>
     </b-navbar-brand>
-
+    
+    <span class="badge badge-pill version" v-if="$store && $store.state.sist2Info">
+      v{{ sist2Version() }}
+    </span>
+      
     <b-button class="ml-auto" to="/task" variant="link">{{ $t("tasks") }}</b-button>
   </b-navbar>
 </template>


### PR DESCRIPTION
Added the version badge-pill to the sist2-admin page so you can check the version without going to the main search frontend.

I pulled this code directly from sist2-view. 

Alternatively / Additionally, maybe move / copy the "Debug Information" from the frontend > Config page to a new page in sist2-admin?