### PR TITLE
PUID and PGID have no effect on elasticsearch container

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,11 @@ services:
     image: elasticsearch:7.17.9
     restart: unless-stopped
     volumes:
-      # This directory must have 1000:1000 permissions (or update PUID & PGID below)
+      # This directory must have 1000:1000 permissions
       - /data/sist2-es-data/:/usr/share/elasticsearch/data
     environment:
       - "discovery.type=single-node"
       - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
-      - "PUID=1000"
-      - "PGID=1000"
   sist2-admin:
     image: simon987/sist2:3.4.2-x64-linux
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,11 @@ services:
     image: elasticsearch:7.17.9
     container_name: sist2-es
     volumes:
-      # This directory must have 1000:1000 permissions (or update PUID & PGID below)
+      # This directory must have 1000:1000 permissions
       - /data/sist2-es-data/:/usr/share/elasticsearch/data
     environment:
       - "discovery.type=single-node"
       - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
-      - "PUID=1000"
-      - "PGID=1000"
   sist2-admin:
     build:
       context: .


### PR DESCRIPTION
PUID and PGID are variables popularized by [linuxserver.io](https://docs.linuxserver.io/general/understanding-puid-and-pgid/#why-use-these) but are not docker specific, that would be the --user flag. Elasticsearch does not respect or use these variables in [it's dockerfile](https://github.com/elastic/dockerfiles/blob/8.13/elasticsearch/Dockerfile#L164) or anywhere in their [entry script](https://github.com/elastic/dockerfiles/blob/8.13/elasticsearch/bin/docker-entrypoint.sh)

In fact they have it hardcoded as `uid 1000` `gid 0` in the Dockerfile