### PR TITLE
Add low-memory mode for SQLite index temp storage

### DIFF
--- a/sist2-admin/frontend/src/components/IndexFileOptions.vue
+++ b/sist2-admin/frontend/src/components/IndexFileOptions.vue
@@ -1,0 +1,18 @@
+<template>
+    <div class="card mb-3">
+        <div class="card-header">Index file options</div>
+        <div class="card-body">
+            <div class="form-check form-switch">
+                <input class="form-check-input" type="checkbox" id="lowMemoryMode"
+                       v-model="options.low_memory_mode">
+                <label class="form-check-label" for="lowMemoryMode">Enable low-memory mode</label>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+defineProps({
+    options: { type: Object, required: true }
+});
+</script>

--- a/sist2-admin/frontend/src/views/Job.vue
+++ b/sist2-admin/frontend/src/views/Job.vue
@@ -42,6 +42,8 @@
 
         <JobOptions :job="job"/>
 
+        <IndexFileOptions :options="job.index_file_options"/>
+
         <div class="card mb-3">
             <div class="card-header">Search backend options</div>
             <div class="card-body">
@@ -60,6 +62,7 @@
 import { onMounted, onUnmounted, ref, watch } from "vue";
 
 import BackButton from "../components/BackButton.vue";
+import IndexFileOptions from "../components/IndexFileOptions.vue";
 import JobOptions from "../components/JobOptions.vue";
 import ScanOptions from "../components/ScanOptions.vue";
 import SearchBackendSelect from "../components/SearchBackendSelect.vue";

--- a/sist2-admin/server/db.js
+++ b/sist2-admin/server/db.js
@@ -5,6 +5,7 @@ import { DatabaseSync } from "node:sqlite";
 import { DB_FILE, MIGRATIONS_FOLDER } from "./config.js";
 import { logger } from "./log.js";
 import {
+    INDEX_FILE_OPTION_TYPES,
     JOB_FIELD_TYPES,
     SCAN_OPTION_TYPES,
     SEARCH_BACKEND_TYPES,
@@ -97,6 +98,7 @@ const JOB_COLUMNS = [
     ...Object.keys(JOB_FIELD_TYPES),
     "search_backend",
     "incremental_index",
+    ...Object.keys(INDEX_FILE_OPTION_TYPES).map((field) => `index_file_${field}`),
     ...Object.keys(SCAN_OPTION_TYPES).map((field) => `scan_${field}`)
 ];
 

--- a/sist2-admin/server/low_memory_mode.spec.js
+++ b/sist2-admin/server/low_memory_mode.spec.js
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createDefaultJob, normalizeJob } from "./models.js";
+import { indexArgs, scanArgs } from "./sist2.js";
+
+test("low-memory mode is off by default and can be saved in index-file options", () => {
+    const job = createDefaultJob("documents");
+    assert.equal(job.index_file_options.low_memory_mode, false);
+
+    const updated = normalizeJob({ index_file_options: { low_memory_mode: true } }, job);
+    assert.equal(updated.index_file_options.low_memory_mode, true);
+});
+
+test("scan arguments include low-memory mode only when enabled", () => {
+    const job = createDefaultJob("documents");
+
+    assert.ok(!scanArgs(job.scan_options, job.index_file_options, "/data/documents.sist2")
+        .includes("--low-memory-mode"));
+    assert.ok(scanArgs(job.scan_options, { low_memory_mode: true }, "/data/documents.sist2")
+        .includes("--low-memory-mode"));
+});
+
+test("index arguments include low-memory mode for Elasticsearch and SQLite backends", () => {
+    const job = createDefaultJob("documents");
+    const elasticsearch = {
+        backend_type: "elasticsearch",
+        threads: 1,
+        es_url: "http://localhost:9200",
+        es_index: "sist2",
+        batch_size: 70,
+        es_insecure_ssl: false
+    };
+    const sqlite = { backend_type: "sqlite", search_index: "search.sist2" };
+
+    const indexFileOptions = { low_memory_mode: true };
+
+    assert.ok(indexArgs("documents.sist2", job.index_options, indexFileOptions, elasticsearch, null, null)
+        .includes("--low-memory-mode"));
+    assert.ok(indexArgs("documents.sist2", job.index_options, indexFileOptions, sqlite, null, null)
+        .includes("--low-memory-mode"));
+});

--- a/sist2-admin/server/migrations/004_index_file_low_memory_mode.sql
+++ b/sist2-admin/server/migrations/004_index_file_low_memory_mode.sql
@@ -1,0 +1,1 @@
+ALTER TABLE job ADD COLUMN index_file_low_memory_mode INTEGER NOT NULL DEFAULT 0;

--- a/sist2-admin/server/models.js
+++ b/sist2-admin/server/models.js
@@ -3,6 +3,10 @@ const TYPE_INTEGER = "integer";
 const TYPE_REAL = "real";
 const TYPE_BOOLEAN = "boolean";
 
+export const INDEX_FILE_OPTION_TYPES = {
+    low_memory_mode: TYPE_BOOLEAN
+};
+
 export const SCAN_OPTION_TYPES = {
     path: TYPE_TEXT,
     threads: TYPE_INTEGER,
@@ -167,6 +171,7 @@ function mapToRow(types, obj, prefix) {
 export function rowToJob(row, userScripts) {
     const job = mapFromRow(JOB_FIELD_TYPES, row, "");
     job.name = row.name;
+    job.index_file_options = mapFromRow(INDEX_FILE_OPTION_TYPES, row, "index_file_");
     job.scan_options = mapFromRow(SCAN_OPTION_TYPES, row, "scan_");
     job.index_options = {
         search_backend: fromRow(TYPE_TEXT, row.search_backend),
@@ -179,6 +184,7 @@ export function rowToJob(row, userScripts) {
 export function jobToParams(job) {
     const params = mapToRow(JOB_FIELD_TYPES, job, "");
     params.name = job.name;
+    Object.assign(params, mapToRow(INDEX_FILE_OPTION_TYPES, job.index_file_options, "index_file_"));
     Object.assign(params, mapToRow(SCAN_OPTION_TYPES, job.scan_options, "scan_"));
     params.search_backend = toRow(TYPE_TEXT, job.index_options.search_backend);
     params.incremental_index = toRow(TYPE_BOOLEAN, job.index_options.incremental_index);
@@ -240,6 +246,9 @@ export function createDefaultJob(name) {
         last_index_date: null,
         status: "created",
         do_full_scan: false,
+        index_file_options: {
+            low_memory_mode: false
+        },
         scan_options: {
             // Not "/": a job is not runnable until someone says what to scan
             path: "",
@@ -319,6 +328,11 @@ export function normalizeJob(body, existing) {
     for (const field of CLIENT_JOB_FIELDS) {
         if (body[field] !== undefined) {
             job[field] = coerce(JOB_FIELD_TYPES[field], body[field]);
+        }
+    }
+    for (const field of Object.keys(INDEX_FILE_OPTION_TYPES)) {
+        if (body.index_file_options !== undefined && body.index_file_options[field] !== undefined) {
+            job.index_file_options[field] = coerce(INDEX_FILE_OPTION_TYPES[field], body.index_file_options[field]);
         }
     }
     for (const field of Object.keys(SCAN_OPTION_TYPES)) {

--- a/sist2-admin/server/sist2.js
+++ b/sist2-admin/server/sist2.js
@@ -37,7 +37,7 @@ export function sist2Version() {
     return versionPromise;
 }
 
-export function scanArgs(scanOptions, outputPath) {
+export function scanArgs(scanOptions, indexFileOptions, outputPath) {
     const options = scanOptions;
     const args = [
         "scan",
@@ -98,16 +98,23 @@ export function scanArgs(scanOptions, outputPath) {
     if (options.checksums) {
         args.push("--checksums");
     }
+    if (indexFileOptions.low_memory_mode) {
+        args.push("--low-memory-mode");
+    }
 
     return args;
 }
 
-export function indexArgs(indexPath, indexOptions, backend, mappingsFile, settingsFile) {
+export function indexArgs(indexPath, indexOptions, indexFileOptions, backend, mappingsFile, settingsFile) {
     const absolutePath = path.join(DATA_FOLDER, indexPath);
 
     if (backend.backend_type === "sqlite") {
         const searchIndexAbsolute = path.join(DATA_FOLDER, backend.search_index);
-        return ["sqlite-index", absolutePath, "--search-index", searchIndexAbsolute];
+        const args = ["sqlite-index", absolutePath, "--search-index", searchIndexAbsolute];
+        if (indexFileOptions.low_memory_mode) {
+            args.push("--low-memory-mode");
+        }
+        return args;
     }
 
     const args = [
@@ -130,6 +137,9 @@ export function indexArgs(indexPath, indexOptions, backend, mappingsFile, settin
     }
     if (indexOptions.incremental_index) {
         args.push("--incremental-index");
+    }
+    if (indexFileOptions.low_memory_mode) {
+        args.push("--low-memory-mode");
     }
 
     return args;

--- a/sist2-admin/server/tasks.js
+++ b/sist2-admin/server/tasks.js
@@ -134,7 +134,7 @@ export class ScanTask extends Task {
         }
 
         const outputPath = path.join(DATA_FOLDER, output);
-        const args = scanArgs(job.scan_options, outputPath);
+        const args = scanArgs(job.scan_options, job.index_file_options, outputPath);
 
         const returnCode = await runSist2(
             args,
@@ -202,6 +202,7 @@ export class IndexTask extends Task {
         const args = indexArgs(
             job.index_path,
             job.index_options,
+            job.index_file_options,
             backend,
             mappingsFile,
             settingsFile

--- a/src/cli.h
+++ b/src/cli.h
@@ -13,6 +13,7 @@ typedef struct scan_args {
     int tn_size;
     int content_size;
     int threads;
+    int low_memory_mode;
     int incremental;
     int optimize_database;
     char *output;
@@ -69,6 +70,7 @@ typedef struct index_args {
     int async_script;
     int force_reset;
     int threads;
+    int low_memory_mode;
     int incremental;
 } index_args_t;
 
@@ -78,6 +80,7 @@ typedef struct {
     int rebuild;
     int optimize;
     int skip_spellfix;
+    int low_memory_mode;
 } sqlite_index_args_t;
 
 typedef enum {

--- a/src/ctx.h
+++ b/src/ctx.h
@@ -35,6 +35,7 @@ typedef struct {
     const char **argv;
 
     int threads;
+    int low_memory_mode;
     int incremental;
     int depth;
     /** Seconds a worker may spend on one file before it is killed and restarted, 0 to disable */

--- a/src/database/database.c
+++ b/src/database/database.c
@@ -213,6 +213,10 @@ void database_initialize(database_t *db) {
 }
 
 void database_open(database_t *db) {
+    database_open_with_options(db, FALSE);
+}
+
+void database_open_with_options(database_t *db, int low_memory_mode) {
     LOG_DEBUGF("database.c", "Opening database %s (%d)", db->filename, db->type);
 
     CRASH_IF_NOT_SQLITE_OK(sqlite3_open(db->filename, &db->db));
@@ -223,7 +227,7 @@ void database_open(database_t *db) {
 //    CRASH_IF_NOT_SQLITE_OK(sqlite3_exec(db->db, "PRAGMA cache_size = -200000;", NULL, NULL, NULL));
     CRASH_IF_NOT_SQLITE_OK(sqlite3_exec(db->db, "PRAGMA synchronous = OFF;", NULL, NULL, NULL));
 
-    if (db->type == INDEX_DATABASE) {
+    if (db->type == INDEX_DATABASE && !low_memory_mode) {
         CRASH_IF_NOT_SQLITE_OK(sqlite3_exec(db->db, "PRAGMA temp_store = memory;", NULL, NULL, NULL));
     }
 

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -106,6 +106,8 @@ void database_initialize(database_t *db);
 
 void database_open(database_t *db);
 
+void database_open_with_options(database_t *db, int low_memory_mode);
+
 void database_close(database_t *, int optimize);
 
 void database_increment_version(database_t *db);

--- a/src/database/database.spec.cpp
+++ b/src/database/database.spec.cpp
@@ -54,6 +54,17 @@ protected:
         std::filesystem::remove(db_path);
     }
 
+    int temp_store() const {
+        sqlite3_stmt *stmt = nullptr;
+        if (sqlite3_prepare_v2(db->db, "PRAGMA temp_store", -1, &stmt, nullptr) != SQLITE_OK) {
+            return -1;
+        }
+
+        const int result = sqlite3_step(stmt) == SQLITE_ROW ? sqlite3_column_int(stmt, 0) : -1;
+        sqlite3_finalize(stmt);
+        return result;
+    }
+
     /** A model a user script would have registered, and one chunk of a document it embedded */
     void write_embedding(int doc_id, int start, int end, float value, int model_id = 1,
                          const char *model_path = "idx_384.test") {
@@ -92,6 +103,19 @@ protected:
         return doc;
     }
 };
+
+/** The default sets in-memory temporary storage for better performance. */
+TEST_F(DatabaseTest, DefaultModeForcesTemporaryDataIntoMemory) {
+    EXPECT_EQ(temp_store(), 2);
+}
+
+/** Low-memory mode deliberately does not force temporary storage into memory for an index database. */
+TEST_F(DatabaseTest, LowMemoryModeDoesNotOverrideSqliteTemporaryStorage) {
+    database_close(db, FALSE);
+    database_open_with_options(db, TRUE);
+
+    EXPECT_EQ(temp_store(), 0);
+}
 
 /** What SQLite would use for its temporary files, the way database.c looks it up */
 static const char *temp_directory() {

--- a/src/main.c
+++ b/src/main.c
@@ -36,7 +36,7 @@ void database_scan_begin(scan_args_t *args) {
 
     if (args->incremental) {
         // Update existing descriptor
-        database_open(db);
+        database_open_with_options(db, args->low_memory_mode);
         index_descriptor_t *original_desc = database_read_index_descriptor(db);
 
         // copy original index id
@@ -70,7 +70,7 @@ void database_scan_begin(scan_args_t *args) {
         desc->id = random_index_id();
 
         database_initialize(db);
-        database_open(db);
+        database_open_with_options(db, args->low_memory_mode);
         database_write_index_descriptor(db, desc);
     }
 
@@ -202,6 +202,7 @@ void initialize_scan_context(scan_args_t *args) {
     ScanCtx.msdoc_ctx.msdoc_mime = mime_get_mime_by_string("application/msword");
 
     ScanCtx.threads = args->threads;
+    ScanCtx.low_memory_mode = args->low_memory_mode;
     ScanCtx.incremental = args->incremental;
     ScanCtx.depth = args->depth;
     ScanCtx.job_timeout = args->job_timeout;
@@ -297,7 +298,7 @@ void sist2_scan(scan_args_t *args) {
     ScanCtx.master = NULL;
 
     database_t *db = database_create(args->output, INDEX_DATABASE);
-    database_open(db);
+    database_open_with_options(db, args->low_memory_mode);
 
     if (args->incremental != FALSE) {
         database_incremental_scan_end(db);
@@ -334,7 +335,7 @@ void sist2_index(index_args_t *args) {
     }
 
     database_t *db = database_create(args->index_path, INDEX_DATABASE);
-    database_open(db);
+    database_open_with_options(db, args->low_memory_mode);
     index_descriptor_t *desc = database_read_index_descriptor(db);
     database_close(db, FALSE);
 
@@ -355,7 +356,7 @@ void sist2_index(index_args_t *args) {
     int cnt = 0;
 
     db = database_create(args->index_path, INDEX_DATABASE);
-    database_open(db);
+    database_open_with_options(db, args->low_memory_mode);
 
     long long source_version = database_get_version(db);
     long long indexed_version = IndexCtx.needs_es_connection ? elastic_get_indexed_version(desc->id) : 0;
@@ -414,7 +415,7 @@ void sist2_index(index_args_t *args) {
 
 void sist2_sqlite_index(sqlite_index_args_t *args) {
     database_t *db = database_create(args->index_path, INDEX_DATABASE);
-    database_open(db);
+    database_open_with_options(db, args->low_memory_mode);
 
     database_t *search_db = database_create(args->search_index_path, FTS_DATABASE);
     database_initialize(search_db);
@@ -531,6 +532,7 @@ int main(int argc, const char *argv[]) {
     int common_threads = 0;
     int common_optimize_database = 0;
     char *common_search_index = NULL;
+    int common_low_memory_mode = 0;
 
     struct argparse_option options[] = {
             OPT_HELP(),
@@ -539,6 +541,8 @@ int main(int argc, const char *argv[]) {
             OPT_BOOLEAN(0, "verbose", &LogCtx.verbose, "Turn on logging."),
             OPT_BOOLEAN(0, "very-verbose", &LogCtx.very_verbose, "Turn on debug messages."),
             OPT_BOOLEAN(0, "json-logs", &LogCtx.json_logs, "Output logs in JSON format."),
+            OPT_BOOLEAN(0, "low-memory-mode", &common_low_memory_mode,
+                        "Disable in-memory temporary storage."),
 
             OPT_GROUP("Scan options"),
             OPT_INTEGER('t', "threads", &common_threads, "Number of threads. DEFAULT: 1"),
@@ -673,11 +677,14 @@ int main(int argc, const char *argv[]) {
 
     index_args->script_path = common_script_path;
     index_args->threads = common_threads;
+    index_args->low_memory_mode = common_low_memory_mode;
     scan_args->threads = common_threads;
+    scan_args->low_memory_mode = common_low_memory_mode;
 
     scan_args->optimize_database = common_optimize_database;
 
     sqlite_index_args->search_index_path = common_search_index;
+    sqlite_index_args->low_memory_mode = common_low_memory_mode;
     web_args->search_index_path = common_search_index;
 
     if (argc == 0) {

--- a/src/worker/master.c
+++ b/src/worker/master.c
@@ -558,7 +558,7 @@ scan_master_t *scan_master_create(const int worker_count, const int print_progre
 
     // This thread is the only writer the index database ever sees
     ProcData.index_db = database_create(ScanCtx.index.path, INDEX_DATABASE);
-    database_open(ProcData.index_db);
+    database_open_with_options(ProcData.index_db, ScanCtx.low_memory_mode);
     master->index_db = ProcData.index_db;
 
     return master;


### PR DESCRIPTION
Fixes #562 

- [x] CLI implementation
- [x] Web Admin implementation
- [x] Run an end-2-end test

This PR adds a low-memory mode option to job configuration (WebAdmin) and scan/index command (CLI).

When enabled, sist2 no longer forces SQLite temporary tables and transient indexes associated with the `.sist2` index file into memory during the scan and index stages. Instead, SQLite uses its configured default temporary-storage strategy, which is normally disk-backed. This reduces peak process memory usage and provides an alternative for memory-constrained environments where large jobs might otherwise OOM.

An end-to-end scan and index test over 159,000,697 documents with low-memory mode enabled completed with peak RAM usage of a little over 16 GiB. The dominant memory use came from Elasticsearch/Lucene merge activity.

<details>

<summary>More details</summary>

Sist2's stats after job ends:

<img width="1439" height="159" alt="image" src="https://github.com/user-attachments/assets/a887ffff-fd06-44c1-bdc3-792548f58d53" />
<img width="1434" height="184" alt="image" src="https://github.com/user-attachments/assets/8c946dfe-f13f-496a-bca9-405d09a8d591" />

ElasticSearch's stats after job ends:

<img width="1151" height="729" alt="image" src="https://github.com/user-attachments/assets/66497698-996c-4a79-9ccf-7a3feebedc9f" />

Docker setup:

`compose.yml`

```compose
services:
  elasticsearch:
    environment:
      - discovery.type=single-node
      - ES_JAVA_OPTS=-Xms16g -Xmx16g
    group_add:
      - '0'
    healthcheck:
      interval: 10s
      retries: 12
      start_period: 30s
      test:
        - CMD-SHELL
        - >-
          curl -fsS
          'http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s'
          >/dev/null || exit 1
      timeout: 6s
    image: elasticsearch:7.17.9
    restart: unless-stopped
    user: '568:568'
    volumes:
      - /mnt/pool0/sist2/es-data:/usr/share/elasticsearch/data
  elasticsearch-init:
    command:
      - |
        curl -fsS \
          -X PUT \
          -H 'Content-Type: application/json' \
          --data-binary @/config/sist2-index-template.json \
          http://elasticsearch:9200/_index_template/sist2
    depends_on:
      elasticsearch:
        condition: service_healthy
    entrypoint:
      - /bin/sh
      - '-ec'
    image: curlimages/curl:8.12.1
    restart: 'no'
    volumes:
      - >-
        /mnt/pool0/sist2/elasticsearch/sist2-index-template.json:/config/sist2-index-template.json:ro
  sist2-admin:
    command:
      - /root/sist2-admin/server/main.js
    depends_on:
      elasticsearch-init:
        condition: service_completed_successfully
    entrypoint: node
    environment:
      - SQLITE_TMPDIR=/sist2-sqlite-tmp
    image: sist2:dev
    ports:
      - '4090:4090'
      - '8080:8080'
    restart: unless-stopped
    volumes:
      - /mnt/pool0/sist2/admin-data/:/sist2-admin/
      - /mnt/pool0/sist2/sqlite-tmp/:/sist2-sqlite-tmp/
      - /mnt/pool0/xuan:/host:ro

```

`sist2-index-template.json`

```
{
  "index_patterns": ["sist2*"],
  "priority": 500,
  "version": 1,
  "_meta": {
    "description": "sist2 index settings"
  },
  "template": {
    "settings": {
      "number_of_shards": 8,
      "merge.scheduler.max_thread_count": 1
    }
  }
}
```

</details>